### PR TITLE
Add Profiler & Update Sweep args & Update CustomLateFusionNet

### DIFF
--- a/algorithms/il/model/aux.py
+++ b/algorithms/il/model/aux.py
@@ -114,7 +114,7 @@ class LateFusionAuxNet(LateFusionNet):
 
         return nn.Sequential(*layers)
 
-    def get_embedded_obs(self, obs, masks=None, other_info=None):
+    def get_context(self, obs, masks=None, other_info=None):
         """Get the embedded observation."""
         batch = obs.shape[0]
         ego_state, road_objects, road_graph = self._unpack_obs(obs, num_stack=5)

--- a/algorithms/il/model/bc.py
+++ b/algorithms/il/model/bc.py
@@ -5,127 +5,103 @@ import torch.nn.functional as F
 import numpy as np
 from typing import List
 
-from networks.perm_eq_late_fusion import LateFusionNet
+from networks.perm_eq_late_fusion import CustomLateFusionNet
 from algorithms.il.model.bc_utils.wayformer import SelfAttentionBlock, PerceiverEncoder
 from algorithms.il.model.bc_utils.head import *
 
 
-class ContFeedForward(LateFusionNet):
-    def __init__(self,  env_config, exp_config, loss='l1', num_stack=5, use_tom=None):
-        super(ContFeedForward, self).__init__(None, env_config, exp_config)
-        self.num_stack = num_stack
-
+class ContFeedForward(CustomLateFusionNet):
+    def __init__(self,  env_config, net_config, head_config, loss, num_stack=5):
+        super(ContFeedForward, self).__init__(env_config, net_config)
         self.nn = self._build_network(
             input_dim=(self.ego_input_dim + self.ro_input_dim * self.ro_max + self.rg_input_dim * self.rg_max) * num_stack,
-            net_arch=exp_config.feedforward.hidden_size,
         )
-
-        self.loss_func = loss
         
         if loss in ['l1', 'mse', 'twohot']: # make head module
-            self.arch_shared_net[0] = exp_config.feedforward.hidden_size[-1]
             self.head = ContHead(
-                hidden_size=exp_config.feedforward.hidden_size[-1],
-                net_arch=self.arch_shared_net
+                input_dim=self.nn.last_layer_dim,
+                hidden_dim=head_config.head_dim,
+                hidden_num=head_config.head_num_layers
             )
         elif loss == 'nll':
             self.head = DistHead(
-                input_dim=exp_config.feedforward.hidden_size[-1],
-                hidden_dim=exp_config.gmm.hidden_dim,
-                action_dim=exp_config.gmm.action_dim,
+                input_dim=self.nn.last_layer_dim,
+                hidden_dim=head_config.head_dim,
+                hidden_num=head_config.head_num_layers,
+                action_dim=head_config.action_dim
             )
         elif loss == 'gmm':
             self.head = GMM(
                 network_type=self.__class__.__name__,
-                input_dim=exp_config.feedforward.hidden_size[-1],
-                hidden_dim=exp_config.gmm.hidden_dim,
-                action_dim=exp_config.gmm.action_dim,
-                n_components=exp_config.gmm.n_components,
+                input_dim=self.nn.last_layer_dim,
+                hidden_dim=head_config.head_dim,
+                hidden_num=head_config.head_num_layers,         
+                action_dim=head_config.action_dim,
+                n_components=head_config.n_components,
                 time_dim=1
             )
         else:
             raise ValueError(f"Loss name {loss} is not supported")
 
-    def get_embedded_obs(self, obs, masks=None):
+    def get_context(self, obs, masks=None):
         """Get the embedded observation."""
+        if obs.dim() == 3:
+            obs = obs.reshape(-1, obs.shape[1]*obs.shape[2])
         return self.nn(obs)
-    
+
     def get_action(self, context, deterministic=False):
         """Get the action from the context."""
         return self.head(context, deterministic)
 
     def forward(self, obs, masks=None, deterministic=False):
         """Generate an actions by end-to-end network."""
-        context = self.get_embedded_obs(obs)
+        context = self.get_context(obs)
         actions = self.get_action(context, deterministic)
         return actions
 
-class LateFusionBCNet(LateFusionNet):
-    def __init__(self, env_config, exp_config, loss='l1', num_stack=5, use_tom=None):
-        super(LateFusionBCNet, self).__init__(None, env_config, exp_config)
+class LateFusionBCNet(CustomLateFusionNet):
+    def __init__(self, env_config, net_config, head_config, loss, num_stack=5):
+        super(LateFusionBCNet, self).__init__(env_config, net_config)
         self.num_stack = num_stack
-        
         # Scene encoder
         self.ego_state_net = self._build_network(
             input_dim=self.ego_input_dim * num_stack,
-            net_arch=self.arch_ego_state,
         )
         self.road_object_net = self._build_network(
             input_dim=self.ro_input_dim * num_stack,
-            net_arch=self.arch_road_objects,
         )
         self.road_graph_net = self._build_network(
             input_dim=self.rg_input_dim * num_stack,
-            net_arch=self.arch_road_graph,
         )
-
-        self.loss_func = loss
-        # Aux head
-        if use_tom == 'aux_head':
-            self.aux_action_head = GMM(
-                network_type=self.__class__.__name__,
-                input_dim=self.road_object_layers[-1],
-                hidden_dim=exp_config.gmm.hidden_dim,
-                action_dim=exp_config.gmm.action_dim,
-                n_components=exp_config.gmm.n_components,
-                time_dim=1
-            )
-            self.aux_goal_head = GMM(
-                network_type=self.__class__.__name__,
-                input_dim=self.road_object_layers[-1],
-                hidden_dim=exp_config.gmm.hidden_dim,
-                action_dim=2,
-                n_components=exp_config.gmm.n_components,
-                time_dim=1
-            )
-        else:
-            raise ValueError(f'ToM method "{use_tom}" is not implemented yet!!')
 
         # Action head
         if loss in ['l1', 'mse', 'twohot']: # make head module
             self.head = ContHead(
-                hidden_size=self.shared_net_input_dim,
-                net_arch=self.arch_shared_net
+                input_dim=self.shared_net_input_dim,
+                hidden_dim=head_config.head_dim,
+                hidden_num=head_config.head_num_layers
             )
         elif loss == 'nll':
             self.head = DistHead(
-                input_dim=exp_config.feedforward.hidden_size[-1],
-                hidden_dim=exp_config.gmm.hidden_dim,
-                action_dim=exp_config.gmm.action_dim,
+                input_dim=self.shared_net_input_dim,
+                hidden_dim=head_config.head_dim,
+                hidden_num=head_config.head_num_layers,
+                action_dim=head_config.action_dim
             )
         elif loss == 'gmm':
             self.head = GMM(
                 network_type=self.__class__.__name__,
                 input_dim=self.shared_net_input_dim,
-                hidden_dim=exp_config.gmm.hidden_dim,
-                action_dim=exp_config.gmm.action_dim,
-                n_components=exp_config.gmm.n_components,
+                hidden_dim=head_config.head_dim,
+                hidden_num=head_config.head_num_layers,
+                action_dim=head_config.action_dim,
+                n_components=head_config.n_components,
                 time_dim=1
             )
         else:
             raise ValueError(f"Loss name {loss} is not supported")
-   
-    def _unpack_obs(self, obs_flat, num_stack=1):
+
+    def _unpack_obs(self, obs_flat, num_stack):
         """
         Unpack the flattened observation into the ego state and visible state.
         Args:
@@ -156,28 +132,10 @@ class LateFusionBCNet(LateFusionNet):
         )
 
         return ego_stack, ro_stack, rg_stack
-    
-    def _build_out_network(
-        self, input_dim: int, output_dim: int, net_arch: List[int]
-    ):
-        """Create the output network architecture."""
-        layers = []
-        prev_dim = input_dim
-        for layer_dim in net_arch:
-            layers.append(nn.Linear(prev_dim, layer_dim))
-            layers.append(nn.LayerNorm(layer_dim))
-            layers.append(self.act_func)
-            layers.append(nn.Dropout(self.dropout))
-            prev_dim = layer_dim
 
-        # Add final layer
-        layers.append(nn.Linear(prev_dim, output_dim))
-
-        return nn.Sequential(*layers)
-
-    def get_embedded_obs(self, obs, masks=None):
+    def get_context(self, obs, masks=None):
         """Get the embedded observation."""
-        ego_state, road_objects, road_graph = self._unpack_obs(obs, num_stack=5)
+        ego_state, road_objects, road_graph = self._unpack_obs(obs, self.num_stack)
         ego_state = self.ego_state_net(ego_state)
         road_objects = self.road_object_net(road_objects)
         road_graph = self.road_graph_net(road_graph)
@@ -198,39 +156,26 @@ class LateFusionBCNet(LateFusionNet):
         """Get the action from the context."""
         return self.head(context, deterministic)
 
-    def get_tom(self, context, deterministic=False):
-        """Get the tom info from the context."""
-        other_actions = self.aux_action_head(context, deterministic)
-        other_goals = self.aux_goal_head(context, deterministic)
-        return other_actions, other_goals
-    
-    def forward(self, obs, masks=None, deterministic=False, use_tom=False):
+    def forward(self, obs, masks=None, deterministic=False):
         """Generate an actions by end-to-end network."""
-        context = self.get_embedded_obs(obs, use_tom)
+        context = self.get_context(obs)
         actions = self.get_action(context, deterministic)
-        if use_tom:
-            tom_preds = self.get_tom(context, deterministic)
-            return actions, tom_preds
+
         return actions
 
-
-class LateFusionAttnBCNet(LateFusionNet):
-    def __init__(self, env_config, exp_config, loss='l1', num_stack=5, use_tom=None):
-        super(LateFusionAttnBCNet, self).__init__(None, env_config, exp_config)
-        self.num_stack = num_stack
-        
+class LateFusionAttnBCNet(CustomLateFusionNet):
+    def __init__(self, env_config, net_config, head_config, loss, num_stack=5):
+        super(LateFusionAttnBCNet, self).__init__(env_config, net_config)
+        self.num_stack = num_stack 
         # Scene encoder
         self.ego_state_net = self._build_network(
             input_dim=self.ego_input_dim * num_stack,
-            net_arch=self.arch_ego_state,
         )
         self.road_object_net = self._build_network(
             input_dim=self.ro_input_dim * num_stack,
-            net_arch=self.arch_road_objects,
         )
         self.road_graph_net = self._build_network(
             input_dim=self.rg_input_dim * num_stack,
-            net_arch=self.arch_road_graph,
         )
         
         # Attention
@@ -253,33 +198,34 @@ class LateFusionAttnBCNet(LateFusionNet):
             torch.zeros((1, self.ro_max, 64)),
             requires_grad=True
         )
-        self.loss_func = loss
         
         if loss in ['l1', 'mse', 'twohot']: # make head module
-            self.arch_shared_net[0] = exp_config.feedforward.hidden_size[-1]
             self.head = ContHead(
-                hidden_size=exp_config.feedforward.hidden_size[-1],
-                net_arch=self.arch_shared_net
+                input_dim=self.shared_net_input_dim,
+                hidden_dim=head_config.head_dim,
+                hidden_num=head_config.head_num_layers
             )
         elif loss == 'nll':
             self.head = DistHead(
-                input_dim=exp_config.feedforward.hidden_size[-1],
-                hidden_dim=exp_config.gmm.hidden_dim,
-                action_dim=exp_config.gmm.action_dim,
+                input_dim=self.shared_net_input_dim,
+                hidden_dim=head_config.head_dim,
+                hidden_num=head_config.head_num_layers,
+                action_dim=head_config.action_dim,
             )
         elif loss == 'gmm':
             self.head = GMM(
                 network_type=self.__class__.__name__,
                 input_dim=self.shared_net_input_dim,
-                hidden_dim=exp_config.gmm.hidden_dim,
-                action_dim=exp_config.gmm.action_dim,
-                n_components=exp_config.gmm.n_components,
+                hidden_dim=head_config.head_dim,
+                hidden_num=head_config.head_num_layers,
+                action_dim=head_config.action_dim,
+                n_components=head_config.n_components,
                 time_dim=1
             )
         else:
             raise ValueError(f"Loss name {loss} is not supported")
-    
-    def _unpack_obs(self, obs_flat, num_stack=1):
+
+    def _unpack_obs(self, obs_flat, num_stack):
         """
         Unpack the flattened observation into the ego state and visible state.
         Args:
@@ -299,7 +245,7 @@ class LateFusionAttnBCNet(LateFusionNet):
             .view(-1, num_stack, self.ro_max, self.ro_input_dim)
             .permute(0, 2, 1, 3)  # Reorder to (batch, ro_max, num_stack, ro_input_dim)
             .reshape(-1, self.ro_max, num_stack * self.ro_input_dim)
-         )
+        )
 
         # rg_stack: Original reshape, then combine num_stack and self.rg_input_dim dimensions
         rg_stack = (
@@ -310,31 +256,10 @@ class LateFusionAttnBCNet(LateFusionNet):
         )
 
         return ego_stack, ro_stack, rg_stack
-    
-    def _build_out_network(
-        self, input_dim: int, output_dim: int, net_arch: List[int]
-    ):
-        """Create the output network architecture."""
-        layers = []
-        prev_dim = input_dim
-        for layer_dim in net_arch:
-            layers.append(nn.Linear(prev_dim, layer_dim))
-            layers.append(nn.LayerNorm(layer_dim))
-            layers.append(self.act_func)
-            layers.append(nn.Dropout(self.dropout))
-            prev_dim = layer_dim
 
-        # Add final layer
-        layers.append(nn.Linear(prev_dim, output_dim))
-
-        return nn.Sequential(*layers)
-
-    def get_embedded_obs(self, obs, masks=None):
+    def get_context(self, obs, masks=None):
         """Get the embedded observation."""
-        # Unpack observation
-        ego_state, road_objects, road_graph = self._unpack_obs(obs, num_stack=5)
-        
-        # Embed features
+        ego_state, road_objects, road_graph = self._unpack_obs(obs, num_stack=self.num_stack)
         ego_state = self.ego_state_net(ego_state)
         road_objects = self.road_object_net(road_objects)
         road_objects = road_objects + self.agents_positional_embedding
@@ -361,27 +286,22 @@ class LateFusionAttnBCNet(LateFusionNet):
 
     def forward(self, obs, masks=None, attn_weights=False, deterministic=False):
         """Generate an actions by end-to-end network."""
-        context = self.get_embedded_obs(obs)
+        context = self.get_context(obs)
         actions = self.get_action(context, deterministic)
         return actions
 
-class WayformerEncoder(LateFusionNet):
-    def __init__(self, env_config, exp_config, loss='l1', num_stack=1, rollout_len=10, pred_len=5, use_tom=None):
-        super(WayformerEncoder, self).__init__(None, env_config, exp_config)
-        self.num_stack = num_stack
-        
+class WayformerEncoder(CustomLateFusionNet):
+    def __init__(self, env_config, net_config, head_config, loss, num_stack=1, rollout_len=10, pred_len=5):
+        super(WayformerEncoder, self).__init__(env_config, net_config)        
          # Scene encoder
         self.ego_state_net = self._build_network(
-            input_dim=self.ego_input_dim * num_stack,
-            net_arch=self.arch_ego_state,
+            input_dim=self.ego_input_dim,
         )
         self.road_object_net = self._build_network(
-            input_dim=self.ro_input_dim * num_stack,
-            net_arch=self.arch_road_objects,
+            input_dim=self.ro_input_dim,
         )
         self.road_graph_net = self._build_network(
-            input_dim=self.rg_input_dim * num_stack,
-            net_arch=self.arch_road_graph,
+            input_dim=self.rg_input_dim,
         )
         self.rollout_len = rollout_len
         self.encoder = PerceiverEncoder(64, 64)
@@ -394,32 +314,32 @@ class WayformerEncoder(LateFusionNet):
             requires_grad=True
         )
         self.timestep_linear = nn.Linear(64, pred_len)
-        self.loss_func = loss
         
         if loss in ['l1', 'mse', 'twohot']: # make head module
-            self.arch_shared_net[0] = exp_config.feedforward.hidden_size[-1]
             self.head = ContHead(
-                hidden_size=exp_config.feedforward.hidden_size[-1],
-                net_arch=self.arch_shared_net
+                input_dim=64,
+                hidden_dim=head_config.head_dim,
+                hidden_num=head_config.head_num_layers
             )
         elif loss == 'nll':
             self.head = DistHead(
-                input_dim=exp_config.feedforward.hidden_size[-1],
-                hidden_dim=exp_config.gmm.hidden_dim,
-                action_dim=exp_config.gmm.action_dim,
+                input_dim=64,
+                hidden_dim=head_config.head_dim,
+                hidden_num=head_config.head_num_layers
             )
         elif loss == 'gmm':
             self.head = GMM(
                 network_type=self.__class__.__name__,
                 input_dim=64,
-                hidden_dim=exp_config.gmm.hidden_dim,
-                action_dim=exp_config.gmm.action_dim,
-                n_components=exp_config.gmm.n_components,
+                hidden_dim=head_config.head_dim,
+                hidden_num=head_config.head_num_layers,
+                action_dim=head_config.action_dim,
+                n_components=head_config.n_components,
                 time_dim=pred_len
             )
         else:
             raise ValueError(f"Loss name {loss} is not supported")
-        
+
     def _unpack_obs(self, obs_flat, timestep=91):
         ego_size = self.ego_input_dim
         ro_size = self.ro_input_dim * self.ro_max
@@ -438,13 +358,13 @@ class WayformerEncoder(LateFusionNet):
         )
 
         return ego_stack, ro_stack, rg_stack
-    
-    def get_embedded_obs(self, obs, masks=None):
-        # TODO: Implement function using mask
+
+    def get_context(self, obs, masks=None):
         # Unpack observation
         ego_mask, partner_mask, road_mask = masks
         ego_state, road_objects, road_graph = self._unpack_obs(obs, timestep=self.rollout_len)
         batch_size = obs.shape[0]
+        
         # Embed features
         ego_state = self.ego_state_net(ego_state)
         road_objects = self.road_object_net(road_objects)
@@ -476,6 +396,6 @@ class WayformerEncoder(LateFusionNet):
 
     def forward(self, obs, masks=None, deterministic=False):
         """Generate an actions by end-to-end network."""
-        context = self.get_embedded_obs(obs, masks)
+        context = self.get_context(obs, masks)
         actions = self.get_action(context, deterministic)
         return actions

--- a/baselines/il/config.py
+++ b/baselines/il/config.py
@@ -43,24 +43,28 @@ class EnvConfig:
 
     # Dynamics model
     dynamics_model: str = (
-        "classic"  # Options: "classic", "bicycle", "delta_local", or "state"
+        "delta_local"  # Options: "classic", "bicycle", "delta_local", or "state"
     )
 
     # Action space settings (if discretized)
     # Classic or Invertible Bicycle dynamics model
-    steer_actions: torch.Tensor = torch.round(
-        torch.linspace(-1.0, 1.0, 13), decimals=3
-    )
-    accel_actions: torch.Tensor = torch.round(
-        torch.linspace(-4.0, 4.0, 7), decimals=3
-    )
+    steer_actions=torch.round(
+        torch.linspace(-0.3, 0.3, 7), decimals=3
+    ),
+    accel_actions=torch.round(
+        torch.linspace(-6.0, 6.0, 7), decimals=3
+    ),
     head_tilt_actions: torch.Tensor = torch.Tensor([0])
     
     # Delta Local dynamics model
-    dx: torch.Tensor = torch.round(torch.linspace(-2.0, 2.0, 20), decimals=3)
-    dy: torch.Tensor = torch.round(torch.linspace(-2.0, 2.0, 20), decimals=3)
-    dyaw: torch.Tensor = torch.round(
-        torch.linspace(-3.14, 3.14, 20), decimals=3
+    dx=torch.round(
+        torch.linspace(-6.0, 6.0, 100), decimals=3
+    )
+    dy=torch.round(
+        torch.linspace(-6.0, 6.0, 100), decimals=3
+    )
+    dyaw=torch.round(
+        torch.linspace(-torch.pi, torch.pi, 100), decimals=3
     )
 
     # Global action space settings if StateDynamicsModel is used
@@ -105,57 +109,18 @@ class ExperimentConfig:
     lr: float = 5e-4
     sample_per_epoch: int = 438763
     
-
 @dataclass
 class NetworkConfig:
     # BASE LATEFUSION
-    ego_state_layers = [64, 64]
-    road_object_layers = [64, 64]
-    road_graph_layers = [64, 64]
-    shared_layers = [64, 64]
-    act_func = "tanh"
-    dropout = 0.0
-    last_layer_dim_pi = 64
-    last_layer_dim_vf = 64  
+    network_dim: int = 64
+    network_num_layers: int = 2
+    act_func: str = "tanh"
+    dropout: float = 0.0
 
-    @dataclass
-    class FeedForwardConfig:
-        hidden_size: list = field(default_factory=lambda: [1024, 256])
-        net_arch: list = field(default_factory=lambda: [64, 128])
-    
-    @dataclass
-    class LatefusionConfig:
-        #TODO: latefusion network hyperparameters
-        NotImplemented
-
-    @dataclass
-    class LatefusionAttnConfig:
-        #TODO: latefusion attention network hyperparameters
-        NotImplemented
-    
-    @dataclass
-    class WayformerConfig:
-        #TODO: wayformer network hyperparameters
-        NotImplemented
-    
-    @dataclass
-    class ContHeadConfig:
-        #TODO: conthead hyperparameters
-        NotImplemented 
-    
-    @dataclass
-    class GmmHeadConfig:
-        hidden_dim: int = 128
-        action_dim: int = 3
-        n_components: int = 10
-        time_dim: int = 91
-        
-    # Sub-configurations
-    feedforward: FeedForwardConfig = field(default_factory=FeedForwardConfig)
-    latefusion: LatefusionConfig = field(default_factory=LatefusionConfig)
-    latefusion_attn: LatefusionAttnConfig = field(default_factory=LatefusionAttnConfig)
-    wayformer: WayformerConfig = field(default_factory=WayformerConfig)  
-    
-    conthead: ContHeadConfig = field(default_factory=ContHeadConfig)
-    gmm: GmmHeadConfig = field(default_factory=GmmHeadConfig)
-    
+@dataclass
+class HeadConfig:
+    head_dim: int = 128
+    head_num_layers: int = 2
+    action_dim: int = 3
+    n_components: int = 10
+    time_dim: int = 91

--- a/baselines/il/config.py
+++ b/baselines/il/config.py
@@ -50,10 +50,10 @@ class EnvConfig:
     # Classic or Invertible Bicycle dynamics model
     steer_actions=torch.round(
         torch.linspace(-0.3, 0.3, 7), decimals=3
-    ),
+    )
     accel_actions=torch.round(
         torch.linspace(-6.0, 6.0, 7), decimals=3
-    ),
+    )
     head_tilt_actions: torch.Tensor = torch.Tensor([0])
     
     # Delta Local dynamics model

--- a/baselines/il/run_bc_from_scratch.py
+++ b/baselines/il/run_bc_from_scratch.py
@@ -48,8 +48,8 @@ def parse_args():
     return args
 
 def train():
-    net_config = NetworkConfig()
     env_config = EnvConfig()
+    net_config = NetworkConfig()
     head_config = HeadConfig()
 
     if args.use_wandb:

--- a/baselines/il/sweep.yaml
+++ b/baselines/il/sweep.yaml
@@ -7,13 +7,13 @@ metric:
 parameters:
   # EXPERIMENT
   batch_size:
-    values: [128,256]
+    values: [256,512]
   epochs:
-    value: 1
+    value: 1000
   lr:
     value: 0.0005
   sample_per_epoch:
-    value: 1000
+    value: 438763
 
   # MODEL
   model_name:

--- a/baselines/il/sweep.yaml
+++ b/baselines/il/sweep.yaml
@@ -1,15 +1,26 @@
-program: train.py
+program: run_bc_from_scratch.py
 method: grid
 name: sweep
 metric:
   goal: minimize
   name: eval/loss
 parameters:
-  batch_size: 
+  # EXPERIMENT
+  batch_size:
     values: [128,256]
-  lr:
-    values: [0.0005, 0.004] 
   epochs:
-    value: 1000
+    value: 1
+  lr:
+    value: 0.0005
   sample_per_epoch:
-    value: 438763
+    value: 1000
+
+  # MODEL
+  model_name:
+    values: ["bc","late_fusion"] # ['bc', 'late_fusion', 'attention', 'wayformer']
+  loss_name:
+    value: "gmm" # ['l1', 'mse', 'twohot', 'nll', 'gmm']
+  network_dim:
+    values: [64,128]
+  network_num_layers:
+    values: [2,3]

--- a/profile/wayformer_profiler.py
+++ b/profile/wayformer_profiler.py
@@ -1,0 +1,101 @@
+import torch
+import torch.nn as nn
+import torch.optim as optim
+from torch.utils.data import DataLoader
+from torch.profiler import profile, record_function, ProfilerActivity
+import os, sys
+
+from baselines.il.config import NetworkConfig, ExperimentConfig, EnvConfig
+from baselines.il.dataloader import ExpertDataset
+from algorithms.il.model.bc import *
+from algorithms.il import MODELS, LOSS
+
+def get_dataloader():
+    with np.load("/data/tom/test_trajectory_200.npz") as npz:
+        expert_obs = [npz['obs']]
+        expert_actions = [npz['actions']]
+        expert_masks = [npz['dead_mask']] if 'dead_mask' in npz.keys() else []
+        other_info = [npz['other_info']] if 'other_info' in npz.keys() else []
+        road_mask = [npz['road_mask']] if 'road_mask' in npz.keys() else []
+
+    expert_obs = expert_obs[0][:256,...]
+    expert_actions = expert_actions[0][:256,...]
+    expert_masks = expert_masks[0][:256,...] if len(expert_masks) > 0 else None
+    other_info = other_info[0][:256,...] if len(other_info) > 0 else None
+    road_mask = road_mask[0][:256,...] if len(road_mask) > 0 else None
+
+    data_loader = DataLoader(
+        ExpertDataset(
+            expert_obs, expert_actions, expert_masks,
+            other_info=other_info, road_mask=road_mask,
+            rollout_len=10, pred_len=5
+        ),
+        batch_size=256,
+        shuffle=False,
+        num_workers=int(os.cpu_count() / 2),
+        pin_memory=True
+    )
+    del expert_obs, expert_actions, expert_masks, other_info, road_mask
+    return data_loader
+
+if __name__ == "__main__":
+    torch.cuda.empty_cache()
+    net_config = NetworkConfig()
+    env_config = EnvConfig(
+        dynamics_model='delta_local',
+        steer_actions=torch.round(
+            torch.linspace(-0.3, 0.3, 7), decimals=3
+        ),
+        accel_actions=torch.round(
+            torch.linspace(-6.0, 6.0, 7), decimals=3
+        ),
+        dx=torch.round(
+            torch.linspace(-6.0, 6.0, 100), decimals=3
+        ).to("cuda"),
+        dy=torch.round(
+            torch.linspace(-6.0, 6.0, 100), decimals=3
+        ).to("cuda"),
+        dyaw=torch.round(
+            torch.linspace(-np.pi, np.pi, 100), decimals=3
+        ).to("cuda"),
+    )
+
+    dataloader = get_dataloader()
+    model = MODELS["wayformer"](env_config, net_config, "gmm", 1).to("cuda")
+    optimizer = optim.Adam(model.parameters(), lr=0.0005)
+
+    with profile(
+        activities=[
+            ProfilerActivity.CPU,
+            ProfilerActivity.CUDA
+        ],
+        on_trace_ready=torch.profiler.tensorboard_trace_handler('./log'),  # TensorBoard 저장 경로
+        record_shapes=True,
+        with_stack=True
+    ) as prof:
+        for i, batch in enumerate(dataloader):
+            obs, expert_action, masks, ego_masks, partner_masks, road_masks = batch
+            
+            obs = obs.to("cuda")
+            expert_action = expert_action.to("cuda")
+            masks = masks.to("cuda")
+            ego_masks = ego_masks.to("cuda")
+            partner_masks = partner_masks.to("cuda")
+            road_masks = road_masks.to("cuda")
+            all_masks = [masks, ego_masks, partner_masks, road_masks]
+
+            with record_function("forward_pass(get_context)"):
+                context = model.get_embedded_obs(obs, all_masks[1:])
+            with record_function("forward_pass(get_action)"):
+                pred_actions = model.get_action(context, deterministic=True)
+            with record_function("forward_pass"):
+                pred_actions = model(obs, all_masks[1:], deterministic=True)
+            with record_function("forward_pass(get_loss)"):
+                loss = LOSS["gmm"](model, context, expert_action, all_masks)
+            with record_function("backward_pass"):
+                loss.backward()
+            with record_function("optimization_step"):
+                optimizer.step()
+                optimizer.zero_grad()
+
+    print(prof.key_averages().table(sort_by="cuda_time_total", row_limit=10))


### PR DESCRIPTION
# Profiler
- 모델 시간 분석 도구 추가 (모델 구조 변경에 따라 추후 업데이트 예정)

# Sweep args
- sweep config에 argparse 추가해서 config 변수명으로 같이 사용 (sweep config 우선 적용하도록 조치함)
- sweep 적용을 위해서 기존 모델들의 인자를 hidden_dim, hidden_num 변수로 교체

# CustomLateFusionNet
- 기존 LateFusionNet에서 필요 없는 프로퍼티 및 메소드 제거

# wandb 관련
- wandb 저장 명 변경
- sweep config에 관해서만 tag 설정
- use-wandb
  - 공통 : env config, net config, head config
  - 사용 O : sweep config + argparse config
  - 사용 X : experiment config + argparse config

# Refactoring
- head config와 network config 따로 분리
- get_embedded_obs -> get_context로 함수명 변경
- 모델 저장 명 변경

# TODO
- LateFusionAuxNet모델에 CustomLateFusionNet 적용
- sweep 적용을 위해 모델(encoder, head) 인자들이 바뀌어서 LateFusionAuxNet에도 적용
- 이전이랑 성능이 동일한지 체크
- ContHead의 경우 Dist, GMM과 달리 Residual block으로 이루어지지 않아 확인 필요