### PR TITLE
Fix norm to new object

### DIFF
--- a/algorithms/il/__init__.py
+++ b/algorithms/il/__init__.py
@@ -6,7 +6,7 @@ from algorithms.il.model.aux import *
 
 MODELS = dict(bc=ContFeedForward, late_fusion=LateFusionBCNet,
               attention=LateFusionAttnBCNet, wayformer=WayformerEncoder,
-              early_attn=EarltFusionAttnBCNet,
+              early_attn=EarlyFusionAttnBCNet,
               aux_fusion=LateFusionAuxNet, aux_attn=LateFusionAttnAuxNet)
 
 LOSS = dict(

--- a/algorithms/il/model/bc.py
+++ b/algorithms/il/model/bc.py
@@ -362,9 +362,9 @@ class LateFusionAttnBCNet(CustomLateFusionNet):
         actions = self.get_action(context, deterministic)
         return actions
 
-class EarltFusionAttnBCNet(CustomLateFusionNet):
+class EarlyFusionAttnBCNet(CustomLateFusionNet):
     def __init__(self, env_config, net_config, head_config, loss, num_stack=5, use_tom=None):
-        super(EarltFusionAttnBCNet, self).__init__(env_config, net_config)
+        super(EarlyFusionAttnBCNet, self).__init__(env_config, net_config)
         self.num_stack = num_stack 
         # Scene encoder
         self.ego_state_net = self._build_network(

--- a/algorithms/il/model/bc.py
+++ b/algorithms/il/model/bc.py
@@ -63,10 +63,10 @@ class LateFusionBCNet(CustomLateFusionNet):
         self.ego_state_net = self._build_network(
             input_dim=self.ego_input_dim * num_stack,
         )
-        self.road_object_net = self._build_partner_network(
+        self.road_object_net = self._build_network_v2(
             input_dim=self.ro_input_dim * num_stack,
         )
-        self.road_graph_net = self._build_partner_network(
+        self.road_graph_net = self._build_network_v2(
             input_dim=self.rg_input_dim * num_stack, is_ro=False
         )
 
@@ -163,8 +163,8 @@ class LateFusionBCNet(CustomLateFusionNet):
         mask_zero_ratio_rg = (selected_mask_rg == 0).sum().item() / selected_mask_rg.numel()
         mask_zero_ratio = [mask_zero_ratio_ro, mask_zero_ratio_rg]
 
-        road_objects.masked_fill_(partner_mask.unsqueeze(-1), 0)
-        road_graph.masked_fill_(road_mask.unsqueeze(-1), 0)
+        road_objects.masked_fill(partner_mask.unsqueeze(-1), 0)
+        road_graph.masked_fill(road_mask.unsqueeze(-1), 0)
 
         road_objects = F.max_pool1d(
             road_objects.permute(0, 2, 1), kernel_size=self.ro_max
@@ -195,7 +195,7 @@ class LateFusionAttnBCNet(CustomLateFusionNet):
         self.ego_state_net = self._build_network(
             input_dim=self.ego_input_dim * num_stack,
         )
-        self.road_object_net = self._build_partner_network(
+        self.road_object_net = self._build_network_v2(
             input_dim=self.ro_input_dim * num_stack,
         )
         self.road_graph_net = self._build_network(
@@ -338,8 +338,8 @@ class LateFusionAttnBCNet(CustomLateFusionNet):
         mask_zero_ratio_rg = (selected_mask_rg == 0).sum().item() / selected_mask_rg.numel()
         mask_zero_ratio = [mask_zero_ratio_ro, mask_zero_ratio_rg]
 
-        objects_attn['last_hidden_state'][:, 1:].masked_fill_(ro_masks.unsqueeze(-1), 0)
-        road_graph_attn['last_hidden_state'].masked_fill_(rg_masks.unsqueeze(-1), 0)
+        objects_attn['last_hidden_state'][:, 1:].masked_fill(ro_masks.unsqueeze(-1), 0)
+        road_graph_attn['last_hidden_state'].masked_fill(rg_masks.unsqueeze(-1), 0)
 
         road_objects = F.max_pool1d(
             objects_attn['last_hidden_state'][:, 1:].permute(0, 2, 1), kernel_size=self.ro_max
@@ -370,7 +370,7 @@ class EarltFusionAttnBCNet(CustomLateFusionNet):
         self.ego_state_net = self._build_network(
             input_dim=self.ego_input_dim * num_stack,
         )
-        self.road_object_net = self._build_partner_network(
+        self.road_object_net = self._build_network_v2(
             input_dim=self.ro_input_dim * num_stack,
         )
         self.road_graph_net = self._build_network(
@@ -534,8 +534,8 @@ class EarltFusionAttnBCNet(CustomLateFusionNet):
         mask_zero_ratio_rg = (selected_mask_rg == 0).sum().item() / selected_mask_rg.numel()
         mask_zero_ratio = [mask_zero_ratio_ro, mask_zero_ratio_rg]
 
-        objects_attn.masked_fill_(ro_masks.unsqueeze(-1), 0)
-        road_graph_attn.masked_fill_(rg_masks.unsqueeze(-1), 0)
+        objects_attn.masked_fill(ro_masks.unsqueeze(-1), 0)
+        road_graph_attn.masked_fill(rg_masks.unsqueeze(-1), 0)
 
         road_objects = F.max_pool1d(
             objects_attn.permute(0, 2, 1), kernel_size=self.ro_max

--- a/networks/norms.py
+++ b/networks/norms.py
@@ -26,11 +26,9 @@ class SetBatchNorm(nn.Module):
         self.mask = None
         torch.nn.init.constant_(self.weights, 1.)
         torch.nn.init.constant_(self.biases, 0.)
-        self.ln = nn.LayerNorm(feature_dim)  # Feature-wise LN
 
     def forward(self, x):   # (B, S, D)
         # Masked Batch Normalization
-        x = self.ln(x)
         alive_mask = (~self.mask).unsqueeze(-1)  # (B, S) -> (B, S, 1)
         valid_counts = alive_mask.sum(dim=1, keepdim=True).clamp(min=1)  # (B, 1, 1)
         batch_mask = valid_counts > 1   # (B, 1, 1)


### PR DESCRIPTION
# Norm
- 기존 같은 객체의 norm이 할당되는 문제 수정
- SetBatchNorm에서 LayerNorm 삭제

# 그 외
- _build_partner_network -> _build_network_v2 이름 수정
- EarltFusionAttnBCNet-> EarlyFusionAttnBCNet이름 수정
- masked_fill_ -> masked_fill (out place 연산으로 변경)