### PR TITLE
Update: fixed partner observation and ID to consistent position

### DIFF
--- a/src/sim.cpp
+++ b/src/sim.cpp
@@ -235,7 +235,7 @@ inline void collectPartnerObsSystem(Engine &ctx,
     // Fill the zero padding for the rest of the array
     for (CountT agentIdx = ctx.data().numAgents - 1; agentIdx < consts::kMaxAgentCount - 1; agentIdx++)
     {
-        partner_obs.obs[agentIdx] = PartnerObservation::zero();
+        partner_obs.obs[agentIdx] = PartnerObservation::zero_nonexist();
     }
 }
 

--- a/src/sim.cpp
+++ b/src/sim.cpp
@@ -196,10 +196,9 @@ inline void collectPartnerObsSystem(Engine &ctx,
 
     auto &partner_obs = ctx.get<PartnerObservations>(agent_iface.e);
 
-    CountT arrIndex = 0; CountT agentIdx = 0;
-    while(agentIdx < ctx.data().numAgents - 1)
+    for(CountT agentIdx = 0; agentIdx < ctx.data().numAgents - 1; agentIdx++)
     {
-        Entity other = other_agents.e[agentIdx++];
+        Entity other = other_agents.e[agentIdx];
 
         const Position &other_position = ctx.get<Position>(other);
         const Velocity &other_velocity = ctx.get<Velocity>(other);
@@ -214,21 +213,29 @@ inline void collectPartnerObsSystem(Engine &ctx,
 
         float relative_heading = utils::quatToYaw(relative_orientation);
 
+        // if agent is outside of observation radius, return zero observation
         if(relative_pos.length() > ctx.data().params.observationRadius)
         {
-            continue;
+            partner_obs.obs[agentIdx] = PartnerObservation::zero();
         }
-        partner_obs.obs[arrIndex++] = {
-            .speed = relative_speed,
-            .position = relative_pos,
-            .heading = relative_heading,
-            .vehicle_size = other_size,
-            .type = (float)ctx.get<EntityType>(other),
-            .id = (float)ctx.get<AgentID>(ctx.get<AgentInterfaceEntity>(other).e).id
-        };
+        else
+        {
+            partner_obs.obs[agentIdx] = {
+                .speed = relative_speed,
+                .position = relative_pos,
+                .heading = relative_heading,
+                .vehicle_size = other_size,
+                .type = (float)ctx.get<EntityType>(other),
+                .id = (float)ctx.get<AgentID>(ctx.get<AgentInterfaceEntity>(other).e).id
+            };
+        }
+        
     }
-    while(arrIndex < consts::kMaxAgentCount - 1) {
-        partner_obs.obs[arrIndex++] = PartnerObservation::zero();
+    
+    // Fill the zero padding for the rest of the array
+    for (CountT agentIdx = ctx.data().numAgents - 1; agentIdx < consts::kMaxAgentCount - 1; agentIdx++)
+    {
+        partner_obs.obs[agentIdx] = PartnerObservation::zero();
     }
 }
 

--- a/src/types.hpp
+++ b/src/types.hpp
@@ -251,6 +251,16 @@ namespace madrona_gpudrive
                 .type = static_cast<float>(EntityType::None),
                 .id = -1};
         }
+
+        static inline PartnerObservation zero_nonexist() {
+            return PartnerObservation{
+                .speed = 0,
+                .position = {0, 0},
+                .heading = 0,
+                .vehicle_size = {0, 0, 0},
+                .type = static_cast<float>(EntityType::None),
+                .id = -2};
+        }
     };
 
     // Egocentric observations of other agents


### PR DESCRIPTION
# Partner 관련
- partner observation은 항상 고정된 order 가지도록 설정
- partner id >= 0 -> partner id
- partner id == -1 -> static id
- partner id == -2 -> non exist id 